### PR TITLE
Fix ACL 4 byte selector assumption

### DIFF
--- a/contracts/ScopeGuard.sol
+++ b/contracts/ScopeGuard.sol
@@ -150,7 +150,7 @@ contract ScopeGuard is FactoryFriendly, BaseGuard {
             "Delegate call not allowed to this address"
         );
         require(allowedTargets[to].allowed, "Target address is not allowed");
-        if (data.length >= 4) {
+        if (data.length > 0) {
             require(
                 !allowedTargets[to].scoped ||
                     allowedTargets[to].allowedFunctions[bytes4(data)],


### PR DESCRIPTION
The guard assumes a 4 byte minimum function selector. I.e., any calldata bellow 4bytes is assumed to target the contract's default function.

This assumption does not hold for older solidity compilers. As a result, a 3 byte call data could be used to execute an unauthorised method.

Fix: assume that any non zero calldata will include a selector, and perform ACL

More details on the vulnerability explained here: https://gist.github.com/GNSPS/9f2f95e9aa2dfd166724ed6303cc822d

