### PR TITLE
Add sendAllow and handle short tx data

### DIFF
--- a/contracts/ScopeGuard.sol
+++ b/contracts/ScopeGuard.sol
@@ -117,6 +117,12 @@ contract ScopeGuard is FactoryFriendly, BaseGuard {
         return (allowedTargets[target].scoped);
     }
 
+    /// @dev Returns bool to indicate if an address is scoped.
+    /// @param target Address to check.
+    function isSendAllowed(address target) public view returns (bool) {
+        return (allowedTargets[target].sendAllowed);
+    }
+
     /// @dev Returns bool to indicate if a function signature is allowed for a target address.
     /// @param target Address to check.
     /// @param functionSig Signature to check.

--- a/contracts/ScopeGuard.sol
+++ b/contracts/ScopeGuard.sol
@@ -170,9 +170,8 @@ contract ScopeGuard is FactoryFriendly, BaseGuard {
                     allowedTargets[to].allowedFunctions[bytes4(data)],
                 "Target function is not allowed"
             );
-        } else if (data.length > 0 && data.length < 4) {
-            revert("Function signature too short");
         } else {
+            require(data.length == 0, "Function signature too short");
             require(
                 !allowedTargets[to].scoped || allowedTargets[to].sendAllowed,
                 "Cannot send to this address"

--- a/contracts/ScopeGuard.sol
+++ b/contracts/ScopeGuard.sol
@@ -35,6 +35,7 @@ contract ScopeGuard is FactoryFriendly, BaseGuard {
         bool allowed;
         bool scoped;
         bool delegateCallAllowed;
+        bool sendAllowed;
         mapping(bytes4 => bool) allowedFunctions;
     }
 
@@ -156,10 +157,11 @@ contract ScopeGuard is FactoryFriendly, BaseGuard {
                     allowedTargets[to].allowedFunctions[bytes4(data)],
                 "Target function is not allowed"
             );
+        } else if (data.length > 0 && data.length < 4) {
+            revert("Function signature too short");
         } else {
             require(
-                !allowedTargets[to].scoped ||
-                    allowedTargets[to].allowedFunctions[bytes4(0)],
+                !allowedTargets[to].scoped || allowedTargets[to].sendAllowed,
                 "Cannot send to this address"
             );
         }

--- a/contracts/ScopeGuard.sol
+++ b/contracts/ScopeGuard.sol
@@ -5,13 +5,14 @@ import "@gnosis.pm/zodiac/contracts/guard/BaseGuard.sol";
 import "@gnosis.pm/zodiac/contracts/factory/FactoryFriendly.sol";
 
 contract ScopeGuard is FactoryFriendly, BaseGuard {
-    event SetTargetAllowed(address target, bool isAllowed);
-    event SetTargetScoped(address target, bool isScoped);
-    event SetDelegateCallAllowedOnTarget(address target, bool isAllowed);
+    event SetTargetAllowed(address target, bool allowed);
+    event SetTargetScoped(address target, bool scoped);
+    event SetSendAllowedOnTarget(address target, bool allowed);
+    event SetDelegateCallAllowedOnTarget(address target, bool allowed);
     event SetFunctionAllowedOnTarget(
         address target,
         bytes4 functionSig,
-        bool isAllowed
+        bool allowed
     );
     event ScopeGuardSetup(address indexed initiator, address indexed owner);
 
@@ -68,10 +69,22 @@ contract ScopeGuard is FactoryFriendly, BaseGuard {
     /// @dev Sets whether or not calls to an address should be scoped to specific function signatures.
     /// @notice Only callable by owner.
     /// @param target Address to be scoped/unscoped.
-    /// @param scope Bool to scope (true) or unscope (false) function calls on target.
-    function setScoped(address target, bool scope) public onlyOwner {
-        allowedTargets[target].scoped = scope;
+    /// @param scoped Bool to scope (true) or unscope (false) function calls on target.
+    function setScoped(address target, bool scoped) public onlyOwner {
+        allowedTargets[target].scoped = scoped;
         emit SetTargetScoped(target, allowedTargets[target].scoped);
+    }
+
+    /// @dev Sets whether or not a target can be sent to (incluces fallback/receive functions).
+    /// @notice Only callable by owner.
+    /// @param target Address to be allow/disallow sends to.
+    /// @param allow Bool to allow (true) or disallow (false) sends on target.
+    function setSendAllowedOnTarget(address target, bool allow)
+        public
+        onlyOwner
+    {
+        allowedTargets[target].sendAllowed = allow;
+        emit SetSendAllowedOnTarget(target, allowedTargets[target].sendAllowed);
     }
 
     /// @dev Sets whether or not a specific function signature should be allowed on a scoped target.

--- a/contracts/ScopeGuard.sol
+++ b/contracts/ScopeGuard.sol
@@ -117,7 +117,7 @@ contract ScopeGuard is FactoryFriendly, BaseGuard {
         return (allowedTargets[target].scoped);
     }
 
-    /// @dev Returns bool to indicate if an address is scoped.
+    /// @dev Returns bool to indicate if allowed to send to a target.
     /// @param target Address to check.
     function isSendAllowed(address target) public view returns (bool) {
         return (allowedTargets[target].sendAllowed);

--- a/test/ScopeGuard.spec.ts
+++ b/test/ScopeGuard.spec.ts
@@ -218,7 +218,32 @@ describe("ScopeGuard", async () => {
       const { avatar, guard, tx } = await setupTests();
       await guard.setTargetAllowed(avatar.address, true);
       await guard.setScoped(avatar.address, true);
-      await guard.setAllowedFunction(avatar.address, "0x00000000", true);
+      await guard.setSendAllowedOnTarget(avatar.address, false);
+      await guard.setAllowedFunction(avatar.address, "0x00000000", false);
+      tx.data = "0x00000000";
+      tx.value = 1;
+      await expect(
+        guard.checkTransaction(
+          tx.to,
+          tx.value,
+          tx.data,
+          tx.operation,
+          tx.avatarTxGas,
+          tx.baseGas,
+          tx.gasPrice,
+          tx.gasToken,
+          tx.refundReceiver,
+          tx.signatures,
+          user1.address
+        )
+      ).to.be.revertedWith("Target function is not allowed");
+    });
+
+    it("should send to target is send is allowed", async () => {
+      const { avatar, guard, tx } = await setupTests();
+      await guard.setTargetAllowed(avatar.address, true);
+      await guard.setScoped(avatar.address, true);
+      await guard.setSendAllowedOnTarget(avatar.address, true);
       tx.data = "0x";
       tx.value = 1;
       await expect(
@@ -235,7 +260,7 @@ describe("ScopeGuard", async () => {
           tx.signatures,
           user1.address
         )
-      ).to.be.revertedWith("Cannot send to this address");
+      );
     });
 
     it("should be callable by an avatar", async () => {

--- a/test/ScopeGuard.spec.ts
+++ b/test/ScopeGuard.spec.ts
@@ -410,6 +410,46 @@ describe("ScopeGuard", async () => {
     });
   });
 
+  describe("setSendAllowedOnTarget()", async () => {
+    it("should revert if caller is not owner", async () => {
+      const { guard } = await setupTests();
+      expect(
+        guard.connect(user2).setSendAllowedOnTarget(guard.address, true)
+      ).to.be.revertedWith("caller is not the owner");
+    });
+
+    it("should set sendAllowed to true for a target", async () => {
+      const { guard } = await setupTests();
+
+      expect(await guard.isSendAllowed(guard.address)).to.be.equals(false);
+      expect(guard.setSendAllowedOnTarget(guard.address, true))
+        .to.emit(guard, "SetSendAllowedOnTarget")
+        .withArgs(guard.address, true);
+      expect(await guard.isSendAllowed(guard.address)).to.be.equals(true);
+    });
+
+    it("should set sendAllowed to false for a target", async () => {
+      const { guard } = await setupTests();
+
+      expect(await guard.isSendAllowed(guard.address)).to.be.equals(false);
+      expect(guard.setSendAllowedOnTarget(guard.address, true))
+        .to.emit(guard, "SetSendAllowedOnTarget")
+        .withArgs(guard.address, true);
+      expect(guard.setSendAllowedOnTarget(guard.address, false))
+        .to.emit(guard, "SetSendAllowedOnTarget")
+        .withArgs(guard.address, false);
+      expect(await guard.isSendAllowed(guard.address)).to.be.equals(false);
+    });
+
+    it("should emit SetSendAllowedOnTarget(target, scoped)", async () => {
+      const { guard } = await setupTests();
+
+      expect(guard.setSendAllowedOnTarget(guard.address, true))
+        .to.emit(guard, "SetSendAllowedOnTarget")
+        .withArgs(guard.address, true);
+    });
+  });
+
   describe("setAllowedFunction()", async () => {
     it("should revert if caller is not owner", async () => {
       const { guard } = await setupTests();
@@ -457,7 +497,7 @@ describe("ScopeGuard", async () => {
     });
   });
 
-  describe("isAllowedTarget", async () => {
+  describe("isAllowedTarget()", async () => {
     it("should return false if not set", async () => {
       const { avatar, guard } = await setupTests();
 
@@ -473,7 +513,7 @@ describe("ScopeGuard", async () => {
     });
   });
 
-  describe("isScoped", async () => {
+  describe("isScoped()", async () => {
     it("should return false if not set", async () => {
       const { avatar, guard } = await setupTests();
 
@@ -496,7 +536,30 @@ describe("ScopeGuard", async () => {
     });
   });
 
-  describe("isAllowedFunction", async () => {
+  describe("isSendAllowed()", async () => {
+    it("should return false if not set", async () => {
+      const { avatar, guard } = await setupTests();
+
+      expect(await guard.isSendAllowed(guard.address)).to.be.equals(false);
+    });
+
+    it("should return false if set to false", async () => {
+      const { guard } = await setupTests();
+
+      expect(guard.setSendAllowedOnTarget(guard.address, false));
+      expect(await guard.isSendAllowed(guard.address)).to.be.equals(false);
+    });
+
+    it("should return true if set to true", async () => {
+      const { guard } = await setupTests();
+
+      expect(await guard.isSendAllowed(guard.address)).to.be.equals(false);
+      expect(guard.setSendAllowedOnTarget(guard.address, true));
+      expect(await guard.isSendAllowed(guard.address)).to.be.equals(true);
+    });
+  });
+
+  describe("isAllowedFunction()", async () => {
     it("should return false if not set", async () => {
       const { avatar, guard } = await setupTests();
 
@@ -520,8 +583,8 @@ describe("ScopeGuard", async () => {
     });
   });
 
-  describe("isAllowedToDelegateCall", async () => {
-    it("should return false by default", async () => {
+  describe("isAllowedToDelegateCall()", async () => {
+    it("should return false if not set", async () => {
       const { avatar, guard } = await setupTests();
 
       expect(await guard.isAllowedTarget(avatar.address)).to.be.equals(false);

--- a/test/ScopeGuard.spec.ts
+++ b/test/ScopeGuard.spec.ts
@@ -214,7 +214,7 @@ describe("ScopeGuard", async () => {
       ).to.be.revertedWith("Cannot send to this address");
     });
 
-    it("should revert function sig is 0x00000000 and not explicitly approved", async () => {
+    it("should revert if function sig is 0x00000000 and not explicitly approved", async () => {
       const { avatar, guard, tx } = await setupTests();
       await guard.setTargetAllowed(avatar.address, true);
       await guard.setScoped(avatar.address, true);


### PR DESCRIPTION
This PR adds a `sendAllowed` to `struct Target` and updates the checks to properly handle short function signatures (less than four bytes) and to explicitly allow for sending ETH/native tokens to an address.